### PR TITLE
Fix BibTeX citation syntax for ROSE and RFMiD

### DIFF
--- a/resources/RFMiD.md
+++ b/resources/RFMiD.md
@@ -94,7 +94,7 @@ Publication Date: 2023-01
 ## Citation
 
 ``` 
-Article{data8020029,
+@Article{data8020029,
 AUTHOR = {Panchal, Sachin and Naik, Ankita and Kokare, Manesh and Pachade, Samiksha and Naigaonkar, Rushikesh and Phadnis, Prerana and Bhange, Archana},
 TITLE = {Retinal Fundus Multi-Disease Image Dataset (RFMiD) 2.0: A Dataset of Frequently and Rarely Identified Diseases},
 JOURNAL = {Data},

--- a/resources/ROSE.md
+++ b/resources/ROSE.md
@@ -127,7 +127,7 @@ Publication Date: 2020
 ## Citation
 
 ``` 
-article{ma2021rose:,
+@article{ma2021rose:,
   title={ROSE: a retinal OCT-angiography vessel segmentation dataset and new model},
   author={Ma, Yuhui and Hao, Huaying and Xie, Jianyang and Fu, Huazhu and Zhang, Jiong and Yang, Jianlong and Wang, Zhen and Liu, Jiang and Zheng, Yalin and Zhao, Yitian},
   journal={IEEE Transactions on Medical Imaging},


### PR DESCRIPTION
Fix Bibtex citation syntax for ROSE and RFMiD. fd01dbebed58e3583f8730c71a010612437ab4f3
Missing ```'@'``` before the ```article{}``` block which causes a parsing error when copy/pasting into BibTex or other citation tools.